### PR TITLE
Skipped update firmware file not found  | Missed Raising error

### DIFF
--- a/gude/deployDev.py
+++ b/gude/deployDev.py
@@ -94,8 +94,8 @@ class DeployDev(HttpDevice):
                 if r.status_code == 200:
                     with open(local_filename, 'wb') as fwfile:
                         fwfile.write(r.content)
-            else:
-                raise ValueError(f"Firmware file not found : {local_filename}")
+                else:
+                    raise ValueError(f"Firmware file not found : {local_filename}")
 
         log.info(f"updating to Firmware v{latest_version}")
 

--- a/gude/deployDev.py
+++ b/gude/deployDev.py
@@ -74,7 +74,7 @@ class DeployDev(HttpDevice):
             latest_version = cfg[prodid]['version']
 
         # R2 check requires appendix
-        if 'R2' in prodid:
+        if 'R2' in prodid and ("R2" not in latest_version and "r2" not in latest_version):
             latest_version += '-R2'
 
         needs_update = forced or (latest_version != dev_version)


### PR DESCRIPTION
Firmware file not found error was missed due to an indentation typo.